### PR TITLE
fix(linking-tool): add needed dependency for linking tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,6 @@
     "start": "ng serve",
     "build": "ng build",
     "build:all": "npm run affected:build -- --all",
-    "linking-tool:build-and-copy": "npm run linking-tool:build && npm run linking-tool:copy",
-    "linking-tool:build": "rm -rf dist/libs/linking-tool && mkdir -p dist/libs/linking-tool && tsc -p libs/linking-tool/tsconfig.json",
-    "linking-tool:copy": "cp libs/linking-tool/package.json dist/libs/linking-tool && cp libs/linking-tool/src/lib/collection.json dist/libs/linking-tool/lib && cp libs/linking-tool/src/lib/schematics/generate-links/schema.json dist/libs/linking-tool/lib/schematics",
     "test": "ng test",
     "lint": "./node_modules/.bin/nx lint && ng lint",
     "e2e": "ng e2e",
@@ -54,7 +51,8 @@
     "core-js": "^2.6.9",
     "rxjs": "^6.5.2",
     "zone.js": "~0.10.1",
-    "@nrwl/angular": "^8.4.4"
+    "@nrwl/angular": "^8.4.4",
+    "ts-morph": "^4.0.1"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "~0.802.0",
@@ -82,7 +80,6 @@
     "prettier": "^1.18.2",
     "shelljs": "^0.8.3",
     "standard-version": "^7.0.0",
-    "ts-morph": "^4.0.1",
     "ts-node": "~8.3.0",
     "tsickle": ">=0.36.0",
     "tslib": "^1.10.0",


### PR DESCRIPTION
Add ts-morph to package.json file. Without that linking tool library is not working after installing it through npm.